### PR TITLE
Feature: Mnemonic Validation

### DIFF
--- a/src/slip39.js
+++ b/src/slip39.js
@@ -136,6 +136,10 @@ class Slip39 {
     return slipHelper.combineMnemonics(mnemonics, passphrase);
   }
 
+  static validateMnemonic(mnemonic) {
+    return slipHelper.validateMnemonic(mnemonic);
+  }
+
   fromPath(path) {
     this.validatePath(path);
 

--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -128,7 +128,7 @@ function encodeBigInt(number, paddedLength = 0) {
   }
 
   if (paddedLength !== 0 && result.length > paddedLength) {
-    throw new Error(`Error in ecoding BigInt value, expected less than ${paddedLength} length value, got ${result.length}`);
+    throw new Error(`Error in encoding BigInt value, expected less than ${paddedLength} length value, got ${result.length}`);
   }
 
   return result;

--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -110,7 +110,7 @@ function decodeBigInt(bytes) {
   return result;
 }
 
-function encodeBigInt(number, length = 0) {
+function encodeBigInt(number, paddedLength = 0) {
   let num = number;
   const BYTE_MASK = BigInt(0xff);
   const BIGINT_ZERO = BigInt(0);
@@ -123,8 +123,12 @@ function encodeBigInt(number, length = 0) {
   }
 
   // Zero padding to the length
-  for (let i = result.length; i < length; i++) {
+  for (let i = result.length; i < paddedLength; i++) {
     result.unshift(0);
+  }
+
+  if (paddedLength !== 0 && result.length > paddedLength) {
+    throw new Error(`Error in ecoding BigInt value, expected less than ${paddedLength} length value, got ${result.length}`);
   }
 
   return result;

--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -587,6 +587,16 @@ function decodeMnemonic(mnemonic) {
   }
 }
 
+function validateMnemonic(mnemonic) {
+  try {
+    decodeMnemonic(mnemonic);
+    return true;
+  }
+  catch (error) {
+    return false;
+  }
+}
+
 function groupPrefix(
   identifier, iterationExponent, groupIndex, groupThreshold, groupCount) {
   const idExpInt = BigInt(
@@ -2217,6 +2227,7 @@ exports = module.exports = {
   MIN_ENTROPY_BITS,
   generateIdentifier,
   encodeMnemonic,
+  validateMnemonic,
   splitSecret,
   combineMnemonics,
   crypt

--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -563,7 +563,7 @@ function decodeMnemonic(mnemonic) {
     ITERATION_EXP_WORDS_LENGTH + 2, data.length - CHECKSUM_WORDS_LENGTH);
 
   if (groupCount < groupThreshold) {
-    throw new Error('Invalid mnemonic: ${mnemonic}.\n Group threshold  ($groupThreshold) cannot be greater than group count ($groupCount).');
+    throw new Error(`Invalid mnemonic: ${mnemonic}.\n Group threshold (${groupThreshold}) cannot be greater than group count (${groupCount}).`);
   }
 
   const valueInt = intFromIndices(valueData);

--- a/test/test.js
+++ b/test/test.js
@@ -226,3 +226,87 @@ describe('Invalid Shares', () => {
     });
   });
 });
+
+describe('Mnemonic Validation', () => {
+  describe('Valid Mnemonics', () => {
+    let mnemonics = slip15.fromPath('r/0').mnemonics;
+
+    mnemonics.forEach((mnemonic, index) => {
+      it (`Mnemonic at index ${index} should be valid`, () => {
+        const isValid = slip39.validateMnemonic(mnemonic);
+
+        assert(isValid);
+      });
+    });
+  });
+
+  const vectors = [
+    [
+      "2. Mnemonic with invalid checksum (128 bits)",
+      [
+        "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision kidney"
+      ]
+    ],
+    [
+      "21. Mnemonic with invalid checksum (256 bits)",
+      [
+        "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect lunar"
+      ]
+    ],
+    [
+      "3. Mnemonic with invalid padding (128 bits)",
+      [
+        "duckling enlarge academic academic email result length solution fridge kidney coal piece deal husband erode duke ajar music cargo fitness"
+      ]
+    ],
+    [
+      "22. Mnemonic with invalid padding (256 bits)",
+      [
+        "theory painting academic academic campus sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips facility obtain sister"
+      ]
+    ],
+    [
+      "10. Mnemonics with greater group threshold than group counts (128 bits)",
+      [
+        "music husband acrobat acid artist finance center either graduate swimming object bike medical clothes station aspect spider maiden bulb welcome",
+        "music husband acrobat agency advance hunting bike corner density careful material civil evil tactics remind hawk discuss hobo voice rainbow",
+        "music husband beard academic black tricycle clock mayor estimate level photo episode exclude ecology papa source amazing salt verify divorce"
+      ]
+    ],
+    [
+      "29. Mnemonics with greater group threshold than group counts (256 bits)",
+      [
+        "smirk pink acrobat acid auction wireless impulse spine sprinkle fortune clogs elbow guest hush loyalty crush dictate tracks airport talent",
+        "smirk pink acrobat agency dwarf emperor ajar organize legs slice harvest plastic dynamic style mobile float bulb health coding credit",
+        "smirk pink beard academic alto strategy carve shame language rapids ruin smart location spray training acquire eraser endorse submit peaceful"
+      ]
+    ],
+    [
+      "39. Mnemonic with insufficient length",
+      [
+        "junk necklace academic academic acne isolate join hesitate lunar roster dough calcium chemical ladybug amount mobile glasses verify cylinder"
+      ]
+    ],
+    [
+      "40. Mnemonic with invalid master secret length",
+      [
+        "fraction necklace academic academic award teammate mouse regular testify coding building member verdict purchase blind camera duration email prepare spirit quarter"
+      ]
+    ]
+  ];
+
+  vectors.forEach((item) => {
+    const description = item[0];
+    const mnemonics = item[1];
+
+    describe(description, () => {
+      mnemonics.forEach((mnemonic, index) => {
+        it (`Mnemonic at index ${index} should be invalid`, () => {
+          const isValid = slip39.validateMnemonic(mnemonic);
+
+          assert(isValid === false);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request is a follow up of issue #2 and adds a static `validateMnemonic(mnemonic): Boolean` method to the `Slip39` class so that (slip39) mnemonics can be validated individually before trying to start seed recovery. It allows developers to test whether or not a mnemonic in itself is valid – not a group of mnemonics.

I've used relevant test vectors from `vectors.json` for tests but two vectors are still failing:
- [3. Mnemonic with invalid padding (128 bits)](https://github.com/ilap/slip39-js/compare/master...joernroeder:feature-mnemonic-validation?expand=1#diff-c1129c8b045390789fa8ff62f2c6b4a9R257)
- [22. Mnemonic with invalid padding (256 bits)](https://github.com/ilap/slip39-js/compare/master...joernroeder:feature-mnemonic-validation?expand=1#diff-c1129c8b045390789fa8ff62f2c6b4a9R263)

The error gets thrown in both cases from https://github.com/ilap/slip39-js/blob/master/src/slip39_helper.js#L259. Both tests fail due to the fact that the xor() function (and padding check) gets only called during secret recovery not during mnemonic decoding.

@ilap is this an issue and can it be detected on an individual, per mnemonic (share) basis? From my understanding [**Checksum** (*C*)](https://github.com/satoshilabs/slips/blob/master/slip-0039.md#format-of-the-share-mnemonic) also includes the padded share value.