### PR TITLE
Added type checks for decodeMnemonic and decodeMnemonics

### DIFF
--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -398,6 +398,10 @@ function mnemomicFromIndices(indices) {
 }
 
 function mnemonicToIndices(mnemonic) {
+  if (typeof mnemonic !== 'string') {
+    throw new Error(`Mnemonic expected to be typeof string with white space separated words. Instead found typeof ${typeof mnemonic}.`);
+  }
+
   const words = mnemonic.toLowerCase().split(' ');
   try {
     const result = words.reduce((prev, item) => {
@@ -480,6 +484,9 @@ function combineMnemonics(mnemonics, passphrase = '') {
 }
 
 function decodeMnemonics(mnemonics) {
+  if (!(mnemonics instanceof Array)) {
+    throw new Error('Mnemonics should be an array of strings');
+  }
   const identifiers = new Set();
   const iterationExponents = new Set();
   const groupThresholds = new Set();
@@ -595,8 +602,7 @@ function validateMnemonic(mnemonic) {
   try {
     decodeMnemonic(mnemonic);
     return true;
-  }
-  catch (error) {
+  } catch (error) {
     return false;
   }
 }


### PR DESCRIPTION
Added simple type checks for the decodeMnemonic(s) methods to show friendlier errors when the wrong type is passed.

Also fixed one lint error in slip39_helper.js

