### PR TITLE
Throw exception on invalid words

### DIFF
--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -399,15 +399,14 @@ function mnemomicFromIndices(indices) {
 
 function mnemonicToIndices(mnemonic) {
   const words = mnemonic.toLowerCase().split(' ');
-  try {
-    const result = words.reduce((prev, item) => {
-      const index = WORD_LIST_MAP[item];
-      return prev.concat(index);
-    }, []);
-    return result;
-  } catch (e) {
-    throw new Error(`Invalid mnemonic word ${e}.`);
-  }
+  const result = words.reduce((prev, item) => {
+    const index = WORD_LIST_MAP[item];
+    if (typeof index === 'undefined') {
+      throw new Error(`Invalid mnemonic word ${item}.`);
+    }
+    return prev.concat(index);
+  }, []);
+  return result;
 }
 
 function recoverSecret(threshold, shares) {


### PR DESCRIPTION
The current mnemonicToIndices method doesn't throw an exception when a word can't be mapped to an index. Instead it returns 'undefined' as the index. In the end the checksum at the end fails. This error is slightly misleading.  

In order to debug what was wrong I needed to log the output of the mapping to notice the 'undefined' value. 

Proposed explicitly throwing an exception when a word can't be mapped, clearly indicating which word is problematic. 