### PR TITLE
Fix broken check of share-value-lengths

### DIFF
--- a/src/slip39_helper.js
+++ b/src/slip39_helper.js
@@ -272,9 +272,7 @@ function getSalt(identifier) {
 
 function interpolate(shares, x) {
   let xCoord = new Set(shares.keys());
-  let arr = Array.from(shares.values(), (v) => {
-    v.length;
-  });
+  let arr = Array.from(shares.values(), (v) => v.length);
   let sharesValueLengths = new Set(arr);
 
   if (sharesValueLengths.size !== 1) {


### PR DESCRIPTION
(v) => { v.length; } always returned "undefined" instead of v.length. Since the Set-size is always "1", the length-check is always passed.