### PR TITLE
Implement extendable backup flag

### DIFF
--- a/src/slip39.js
+++ b/src/slip39.js
@@ -34,7 +34,7 @@ class Slip39Node {
 class Slip39 {
   constructor({
     iterationExponent = 0,
-    extendableBackupFlag,
+    extendableBackupFlag = true,
     identifier,
     groupCount,
     groupThreshold

--- a/src/slip39.js
+++ b/src/slip39.js
@@ -34,11 +34,13 @@ class Slip39Node {
 class Slip39 {
   constructor({
     iterationExponent = 0,
+    extendableBackupFlag,
     identifier,
     groupCount,
     groupThreshold
   } = {}) {
     this.iterationExponent = iterationExponent;
+    this.extendableBackupFlag = extendableBackupFlag;
     this.identifier = identifier;
     this.groupCount = groupCount;
     this.groupThreshold = groupThreshold;
@@ -51,6 +53,7 @@ class Slip39 {
       [1, 1, 'Default 1-of-1 group share']
     ],
     iterationExponent = 0,
+    extendableBackupFlag = 1,
     title = 'My default slip39 shares'
   } = {}) {
     if (masterSecret.length * 8 < slipHelper.MIN_ENTROPY_BITS) {
@@ -79,13 +82,14 @@ class Slip39 {
 
     const slip = new Slip39({
       iterationExponent: iterationExponent,
+      extendableBackupFlag: extendableBackupFlag,
       identifier: identifier,
       groupCount: groups.length,
       groupThreshold: threshold
     });
 
     const encryptedMasterSecret = slipHelper.crypt(
-      masterSecret, passphrase, iterationExponent, slip.identifier);
+      masterSecret, passphrase, iterationExponent, slip.identifier, extendableBackupFlag);
 
     const root = slip.buildRecursive(
       new Slip39Node(0, title),
@@ -101,7 +105,8 @@ class Slip39 {
   buildRecursive(currentNode, nodes, secret, threshold, index) {
     // It means it's a leaf.
     if (nodes.length === 0) {
-      const mnemonic = slipHelper.encodeMnemonic(this.identifier, this.iterationExponent, index,
+      const extendableBackupFlag = 0;
+      const mnemonic = slipHelper.encodeMnemonic(this.identifier, this.extendableBackupFlag, this.iterationExponent, index,
         this.groupThreshold, this.groupCount, currentNode.index, threshold, secret);
 
       currentNode.mnemonic = mnemonic;

--- a/test/test.js
+++ b/test/test.js
@@ -322,14 +322,15 @@ describe('Mnemonic Validation', () => {
   });
 });
 
-function itTestArray(t, g, gs) {
+function itTestArray(t, g, gs, e) {
   it(
-    `recover master secret for ${t} shares (threshold=${t}) of ${g} '[1, 1,]' groups",`,
+    `recover master secret for ${t} shares (threshold=${t}) of ${g} '[1, 1,]' groups with extendable backup flag set to ${e}",`,
     () => {
       let slip = slip39.fromArray(MS, {
         groups: gs.slice(0, g),
         passphrase: PASSPHRASE,
-        threshold: t
+        threshold: t,
+        extendableBackupFlag: e
       });
 
       let mnemonics = slip.fromPath('r').mnemonics.slice(0, t);
@@ -345,9 +346,11 @@ describe('Groups test (T=1, N=1 e.g. [1,1]) - ', () => {
   let totalGroups = 16;
   let groups = Array.from(Array(totalGroups), () => [1, 1]);
 
-  for (group = 1; group <= totalGroups; group++) {
-    for (threshold = 1; threshold <= group; threshold++) {
-      itTestArray(threshold, group, groups);
+  for (extendableBackupFlag = 0; extendableBackupFlag <= 1; extendableBackupFlag++) {
+    for (group = 1; group <= totalGroups; group++) {
+      for (threshold = 1; threshold <= group; threshold++) {
+        itTestArray(threshold, group, groups, extendableBackupFlag);
+      }
     }
   }
 });

--- a/test/vectors.json
+++ b/test/vectors.json
@@ -4,13 +4,15 @@
     [
       "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision keyboard"
     ],
-    "bb54aac4b89dc868ba37d9cc21b2cece"
+    "bb54aac4b89dc868ba37d9cc21b2cece",
+    "xprv9s21ZrQH143K4QViKpwKCpS2zVbz8GrZgpEchMDg6KME9HZtjfL7iThE9w5muQA4YPHKN1u5VM1w8D4pvnjxa2BmpGMfXr7hnRrRHZ93awZ"
   ],
   [
     "2. Mnemonic with invalid checksum (128 bits)",
     [
       "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision kidney"
     ],
+    "",
     ""
   ],
   [
@@ -18,6 +20,7 @@
     [
       "duckling enlarge academic academic email result length solution fridge kidney coal piece deal husband erode duke ajar music cargo fitness"
     ],
+    "",
     ""
   ],
   [
@@ -26,13 +29,15 @@
       "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed",
       "shadow pistol academic acid actress prayer class unknown daughter sweater depict flip twice unkind craft early superior advocate guest smoking"
     ],
-    "b43ceb7e57a0ea8766221624d01b0864"
+    "b43ceb7e57a0ea8766221624d01b0864",
+    "xprv9s21ZrQH143K2nNuAbfWPHBtfiSCS14XQgb3otW4pX655q58EEZeC8zmjEUwucBu9dPnxdpbZLCn57yx45RBkwJHnwHFjZK4XPJ8SyeYjYg"
   ],
   [
     "5. Basic sharing 2-of-3 (128 bits)",
     [
       "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed"
     ],
+    "",
     ""
   ],
   [
@@ -41,6 +46,7 @@
       "adequate smoking academic acid debut wine petition glen cluster slow rhyme slow simple epidemic rumor junk tracks treat olympic tolerate",
       "adequate stay academic agency agency formal party ting frequent learn upstairs remember smear leaf damage anatomy ladle market hush corner"
     ],
+    "",
     ""
   ],
   [
@@ -49,6 +55,7 @@
       "peasant leaves academic acid desert exact olympic math alive axle trial tackle drug deny decent smear dominant desert bucket remind",
       "peasant leader academic agency cultural blessing percent network envelope medal junk primary human pumps jacket fragment payroll ticket evoke voice"
     ],
+    "",
     ""
   ],
   [
@@ -58,6 +65,7 @@
       "liberty category beard email beyond should fancy romp founder easel pink holy hairy romp loyalty material victim owner toxic custody",
       "liberty category academic easy being hazard crush diminish oral lizard reaction cluster force dilemma deploy force club veteran expect photo"
     ],
+    "",
     ""
   ],
   [
@@ -66,6 +74,7 @@
       "average senior academic leaf broken teacher expect surface hour capture obesity desire negative dynamic dominant pistol mineral mailman iris aide",
       "average senior academic agency curious pants blimp spew clothes slice script dress wrap firm shaft regular slavery negative theater roster"
     ],
+    "",
     ""
   ],
   [
@@ -75,6 +84,7 @@
       "music husband acrobat agency advance hunting bike corner density careful material civil evil tactics remind hawk discuss hobo voice rainbow",
       "music husband beard academic black tricycle clock mayor estimate level photo episode exclude ecology papa source amazing salt verify divorce"
     ],
+    "",
     ""
   ],
   [
@@ -83,6 +93,7 @@
       "device stay academic always dive coal antenna adult black exceed stadium herald advance soldier busy dryer daughter evaluate minister laser",
       "device stay academic always dwarf afraid robin gravity crunch adjust soul branch walnut coastal dream costume scholar mortgage mountain pumps"
     ],
+    "",
     ""
   ],
   [
@@ -91,6 +102,7 @@
       "hour painting academic academic device formal evoke guitar random modern justice filter withdraw trouble identify mailman insect general cover oven",
       "hour painting academic agency artist again daisy capital beaver fiber much enjoy suitable symbolic identify photo editor romp float echo"
     ],
+    "",
     ""
   ],
   [
@@ -99,6 +111,7 @@
       "guilt walnut academic acid deliver remove equip listen vampire tactics nylon rhythm failure husband fatigue alive blind enemy teaspoon rebound",
       "guilt walnut academic agency brave hamster hobo declare herd taste alpha slim criminal mild arcade formal romp branch pink ambition"
     ],
+    "",
     ""
   ],
   [
@@ -106,6 +119,7 @@
     [
       "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
     ],
+    "",
     ""
   ],
   [
@@ -114,6 +128,7 @@
       "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join",
       "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter"
     ],
+    "",
     ""
   ],
   [
@@ -122,6 +137,7 @@
       "eraser senior decision shadow artist work morning estate greatest pipeline plan ting petition forget hormone flexible general goat admit surface",
       "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
     ],
+    "",
     ""
   ],
   [
@@ -133,7 +149,8 @@
       "eraser senior ceramic round column hawk trust auction smug shame alive greatest sheriff living perfect corner chest sled fumes adequate",
       "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing"
     ],
-    "7c3397a292a5941682d7a4ae2d898d11"
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
   ],
   [
     "18. Threshold number of groups and members in each group (128 bits, case 2)",
@@ -142,7 +159,8 @@
       "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
       "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join"
     ],
-    "7c3397a292a5941682d7a4ae2d898d11"
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
   ],
   [
     "19. Threshold number of groups and members in each group (128 bits, case 3)",
@@ -150,20 +168,23 @@
       "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
       "eraser senior acrobat romp bishop medical gesture pumps secret alive ultimate quarter priest subject class dictate spew material endless market"
     ],
-    "7c3397a292a5941682d7a4ae2d898d11"
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
   ],
   [
     "20. Valid mnemonic without sharing (256 bits)",
     [
       "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect luck"
     ],
-    "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92"
+    "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92",
+    "xprv9s21ZrQH143K41mrxxMT2FpiheQ9MFNmWVK4tvX2s28KLZAhuXWskJCKVRQprq9TnjzzzEYePpt764csiCxTt22xwGPiRmUjYUUdjaut8RM"
   ],
   [
     "21. Mnemonic with invalid checksum (256 bits)",
     [
       "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect lunar"
     ],
+    "",
     ""
   ],
   [
@@ -171,6 +192,7 @@
     [
       "theory painting academic academic campus sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips facility obtain sister"
     ],
+    "",
     ""
   ],
   [
@@ -179,13 +201,15 @@
       "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap",
       "humidity disease academic agency actress jacket gross physics cylinder solution fake mortgage benefit public busy prepare sharp friar change work slow purchase ruler again tricycle involve viral wireless mixture anatomy desert cargo upgrade"
     ],
-    "c938b319067687e990e05e0da0ecce1278f75ff58d9853f19dcaeed5de104aae"
+    "c938b319067687e990e05e0da0ecce1278f75ff58d9853f19dcaeed5de104aae",
+    "xprv9s21ZrQH143K3a4GRMgK8WnawupkwkP6gyHxRsXnMsYPTPH21fWwNcAytijtfyftqNfiaY8LgQVdBQvHZ9FBvtwdjC7LCYxjYruJFuLzyMQ"
   ],
   [
     "24. Basic sharing 2-of-3 (256 bits)",
     [
       "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap"
     ],
+    "",
     ""
   ],
   [
@@ -194,6 +218,7 @@
       "smear husband academic acid deadline scene venture distance dive overall parking bracelet elevator justice echo burning oven chest duke nylon",
       "smear isolate academic agency alpha mandate decorate burden recover guard exercise fatal force syndrome fumes thank guest drift dramatic mule"
     ],
+    "",
     ""
   ],
   [
@@ -202,6 +227,7 @@
       "finger trash academic acid average priority dish revenue academic hospital spirit western ocean fact calcium syndrome greatest plan losing dictate",
       "finger traffic academic agency building lilac deny paces subject threaten diploma eclipse window unknown health slim piece dragon focus smirk"
     ],
+    "",
     ""
   ],
   [
@@ -211,6 +237,7 @@
       "flavor pink beard email diet teaspoon freshman identify document rebound cricket prune headset loyalty smell emission skin often square rebound",
       "flavor pink academic easy credit cage raisin crazy closet lobe mobile become drink human tactics valuable hand capture sympathy finger"
     ],
+    "",
     ""
   ],
   [
@@ -219,6 +246,7 @@
       "column flea academic leaf debut extra surface slow timber husky lawsuit game behavior husky swimming already paper episode tricycle scroll",
       "column flea academic agency blessing garbage party software stadium verify silent umbrella therapy decorate chemical erode dramatic eclipse replace apart"
     ],
+    "",
     ""
   ],
   [
@@ -228,6 +256,7 @@
       "smirk pink acrobat agency dwarf emperor ajar organize legs slice harvest plastic dynamic style mobile float bulb health coding credit",
       "smirk pink beard academic alto strategy carve shame language rapids ruin smart location spray training acquire eraser endorse submit peaceful"
     ],
+    "",
     ""
   ],
   [
@@ -236,6 +265,7 @@
       "fishing recover academic always device craft trend snapshot gums skin downtown watch device sniff hour clock public maximum garlic born",
       "fishing recover academic always aircraft view software cradle fangs amazing package plastic evaluate intend penalty epidemic anatomy quarter cage apart"
     ],
+    "",
     ""
   ],
   [
@@ -244,6 +274,7 @@
       "evoke garden academic academic answer wolf scandal modern warmth station devote emerald market physics surface formal amazing aquatic gesture medical",
       "evoke garden academic agency deal revenue knit reunion decrease magazine flexible company goat repair alarm military facility clogs aide mandate"
     ],
+    "",
     ""
   ],
   [
@@ -252,6 +283,7 @@
       "river deal academic acid average forbid pistol peanut custody bike class aunt hairy merit valid flexible learn ajar very easel",
       "river deal academic agency camera amuse lungs numb isolate display smear piece traffic worthy year patrol crush fact fancy emission"
     ],
+    "",
     ""
   ],
   [
@@ -259,6 +291,7 @@
     [
       "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
     ],
+    "",
     ""
   ],
   [
@@ -267,6 +300,7 @@
       "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
       "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
     ],
+    "",
     ""
   ],
   [
@@ -275,6 +309,7 @@
       "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club",
       "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
     ],
+    "",
     ""
   ],
   [
@@ -286,7 +321,8 @@
       "wildlife deal ceramic snake agree voter main lecture axis kitchen physics arcade velvet spine idea scroll promise platform firm sharp patrol divorce ancestor fantasy forbid goat ajar believe swimming cowboy symbolic plastic spelling",
       "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club"
     ],
-    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b"
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
   ],
   [
     "37. Threshold number of groups and members in each group (256 bits, case 2)",
@@ -295,7 +331,8 @@
       "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
       "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
     ],
-    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b"
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
   ],
   [
     "38. Threshold number of groups and members in each group (256 bits, case 3)",
@@ -303,13 +340,15 @@
       "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
       "wildlife deal acrobat romp anxiety axis starting require metric flexible geology game drove editor edge screw helpful have huge holy making pitch unknown carve holiday numb glasses survive already tenant adapt goat fangs"
     ],
-    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b"
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
   ],
   [
     "39. Mnemonic with insufficient length",
     [
       "junk necklace academic academic acne isolate join hesitate lunar roster dough calcium chemical ladybug amount mobile glasses verify cylinder"
     ],
+    "",
     ""
   ],
   [
@@ -317,6 +356,51 @@
     [
       "fraction necklace academic academic award teammate mouse regular testify coding building member verdict purchase blind camera duration email prepare spirit quarter"
     ],
+    "",
     ""
+  ],
+  [
+    "41. Valid mnemonics which can detect some errors in modular arithmetic",
+    [
+      "herald flea academic cage avoid space trend estate dryer hairy evoke eyebrow improve airline artwork garlic premium duration prevent oven",
+      "herald flea academic client blue skunk class goat luxury deny presence impulse graduate clay join blanket bulge survive dish necklace",
+      "herald flea academic acne advance fused brother frozen broken game ranked ajar already believe check install theory angry exercise adult"
+    ],
+    "ad6f2ad8b59bbbaa01369b9006208d9a",
+    "xprv9s21ZrQH143K2R4HJxcG1eUsudvHM753BZ9vaGkpYCoeEhCQx147C5qEcupPHxcXYfdYMwJmsKXrHDhtEwutxTTvFzdDCZVQwHneeQH8ioH"
+  ],
+  [
+    "42. Valid extendable mnemonic without sharing (128 bits)",
+    [
+      "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    ],
+    "1679b4516e0ee5954351d288a838f45e",
+    "xprv9s21ZrQH143K2w6eTpQnB73CU8Qrhg6gN3D66Jr16n5uorwoV7CwxQ5DofRPyok5DyRg4Q3BfHfCgJFk3boNRPPt1vEW1ENj2QckzVLQFXu"
+  ],
+  [
+    "43. Extendable basic sharing 2-of-3 (128 bits)",
+    [
+      "enemy favorite academic acid cowboy phrase havoc level response walnut budget painting inside trash adjust froth kitchen learn tidy punish",
+      "enemy favorite academic always academic sniff script carpet romp kind promise scatter center unfair training emphasis evening belong fake enforce"
+    ],
+    "48b1a4b80b8c209ad42c33672bdaa428",
+    "xprv9s21ZrQH143K4FS1qQdXYAFVAHiSAnjj21YAKGh2CqUPJ2yQhMmYGT4e5a2tyGLiVsRgTEvajXkxhg92zJ8zmWZas9LguQWz7WZShfJg6RS"
+  ],
+  [
+    "44. Valid extendable mnemonic without sharing (256 bits)",
+    [
+      "impulse calcium academic academic alcohol sugar lyrics pajamas column facility finance tension extend space birthday rainbow swimming purple syndrome facility trial warn duration snapshot shadow hormone rhyme public spine counter easy hawk album"
+    ],
+    "8340611602fe91af634a5f4608377b5235fa2d757c51d720c0c7656249a3035f",
+    "xprv9s21ZrQH143K2yJ7S8bXMiGqp1fySH8RLeFQKQmqfmmLTRwWmAYkpUcWz6M42oGoFMJRENmvsGQmunWTdizsi8v8fku8gpbVvYSiCYJTF1Y"
+  ],
+  [
+    "45. Extendable basic sharing 2-of-3 (256 bits)",
+    [
+      "western apart academic always artist resident briefing sugar woman oven coding club ajar merit pecan answer prisoner artist fraction amount desktop mild false necklace muscle photo wealthy alpha category unwrap spew losing making",
+      "western apart academic acid answer ancient auction flip image penalty oasis beaver multiple thunder problem switch alive heat inherit superior teaspoon explain blanket pencil numb lend punish endless aunt garlic humidity kidney observe"
+    ],
+    "8dc652d6d6cd370d8c963141f6d79ba440300f25c467302c1d966bff8f62300d",
+    "xprv9s21ZrQH143K2eFW2zmu3aayWWd6MJZBG7RebW35fiKcoCZ6jFi6U5gzffB9McDdiKTecUtRqJH9GzueCXiQK1LaQXdgthS8DgWfC8Uu3z7"
   ]
 ]


### PR DESCRIPTION
This pull request implements a [recent revision](https://github.com/satoshilabs/slips/commit/8d060706b549af6443e04f55605b71f65c981663) of the [SLIP-39 specification](https://github.com/satoshilabs/slips/blob/master/slip-0039.md). The highest bit of the iteration exponent has been repurposed for a new "extendable backup flag". Setting the flag indicates that the random identifier is not used as salt in the encryption of the master secret. This makes it possible to create multiple sets of shares, such that each set of shares uses a different identifier and each set of shares leads to the same master secret for every passphrase. This is a desirable property, which unfortunately was not considered in the initial specification. It allows users to start working with their wallet by creating a single-share (1-of-1) scheme and later upgrade to a multi-share scheme while maintaining the same encrypted master secret and passphrases. Existing SLIP-39 shares remain valid. New shares created using the revised specification use a different checksum customization string and are not compatible with older implementations.
